### PR TITLE
Added special handling of IN operator with list of IP subnet

### DIFF
--- a/pynspect/rules.py
+++ b/pynspect/rules.py
@@ -104,6 +104,7 @@ __credits__ = "Pavel Kácha <pavel.kacha@cesnet.cz>, Andrea Kropáčová <andrea
 import collections
 import re
 import datetime
+import ipranges
 
 # for python2 compatibility: conversion of datetime
 import calendar
@@ -366,6 +367,20 @@ class RuleTreeTraverser():
     """
     Definitions of all comparison binary operations.
     """
+
+    def __is_ip_list(self, right):
+        for r in right:
+            tr = type(r)
+            if tr is ipranges.IP4Net or tr is ipranges.IP6Net or tr is ipranges.IP4Range or tr is ipranges.IP6Range:
+                return True
+        return False
+
+    def __op_in_iplist(self, left, right):
+        for r in right:
+            if left in r:
+                return True
+        return False
+
     binops_comparison = {
         'OP_LIKE': lambda x, y : re.search(y, x),
         'OP_IN':   lambda x, y : x in y,
@@ -428,10 +443,16 @@ class RuleTreeTraverser():
             if res:
                 return True
         elif operation in ['OP_IN']:
-            for l in left:
-                res = self.binops_comparison[operation](l, right)
-                if res:
-                    return True
+            if not self.__is_ip_list(right):
+                for l in left:
+                    res = self.binops_comparison[operation](l, right)
+                    if res:
+                        return True
+            else:
+                for l in left:
+                    res = self.__op_in_iplist(l, right)
+                    if res:
+                        return True
         else:
             for l in left:
                 if l is None:

--- a/pynspect/tests/test_filters_idea.py
+++ b/pynspect/tests/test_filters_idea.py
@@ -389,5 +389,12 @@ class TestMentatDataObjectFilterIDEA(unittest.TestCase):
         self.assertEqual(repr(rule), "COMPBINOP(VARIABLE('Source.IP4') OP_IN LIST(IPV4(IP4('188.14.166.39')), IPV4(IP4('188.14.166.40')), IPV4(IP4('188.14.166.41'))))")
         self.assertEqual(flt.filter(rule, msg_idea), True)
 
+        # list with CIDR addresses
+        rule = psr.parse('(Source.IP4 in ["188.14.166.0/24","10.0.0.0/8","189.14.166.41"])')
+        self.assertEqual(repr(rule), "COMPBINOP(VARIABLE('Source.IP4') OP_IN LIST(CONSTANT('188.14.166.0/24'), CONSTANT('10.0.0.0/8'), CONSTANT('189.14.166.41')))")
+        rule = cpl.compile(rule)
+        self.assertEqual(repr(rule), "COMPBINOP(VARIABLE('Source.IP4') OP_IN LIST(IPV4(IP4Net('188.14.166.0/24')), IPV4(IP4Net('10.0.0.0/8')), IPV4(IP4('189.14.166.41'))))")
+        self.assertEqual(flt.filter(rule, msg_idea), True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
test_filters_idea.py now contains one new test where Source.IP4 is
compared with a list with IP4Net.  In such case, it is not possible to
use lambda function `x in y` because it evaluates as an exact match.

This is a patch that improves RuleTreeTraverser in order to support this
kind of lists (all tests pass), however, it may not be an ideal solution...

Therefore, I'm asking for review/hint.